### PR TITLE
add/remove more hooks to turn-on and turn-off defuns

### DIFF
--- a/auto-dim-other-buffers.el
+++ b/auto-dim-other-buffers.el
@@ -56,6 +56,8 @@
 (defun turn-off-auto-dim-other-buffers ()
   (remove-hook 'pre-command-hook 'adob/pre-command-hook)
   (remove-hook 'post-command-hook 'adob/post-command-hook)
+  (remove-hook 'focus-out-hook 'adob/dim-all-windows)
+  (remove-hook 'focus-in-hook 'adob/after-change-major-mode-hook)
   (remove-hook 'after-change-major-mode-hook 'adob/after-change-major-mode-hook)
   (remove-hook 'next-error-hook 'adob/after-change-major-mode-hook)
   (adob/undim-all-windows))
@@ -65,6 +67,8 @@
   (adob/dim-all-windows)
   (add-hook 'pre-command-hook 'adob/pre-command-hook)
   (add-hook 'post-command-hook 'adob/post-command-hook)
+  (add-hook 'focus-out-hook 'adob/dim-all-windows)
+  (add-hook 'focus-in-hook 'adob/after-change-major-mode-hook)
   (add-hook 'after-change-major-mode-hook 'adob/after-change-major-mode-hook)
   (add-hook 'next-error-hook 'adob/after-change-major-mode-hook))
 


### PR DESCRIPTION
This properly sets the window dimming when using modes that implement
`next-error` by undimming the buffer of the error you are jumping to.

It will also dim all windows when you lose focus of Emacs 24.4+ and undim
the active buffer when you gain focus back. It's helpful for something
like a multi-monitor setup where you need to know which screen's app
currently has focus.
